### PR TITLE
Set focal length separately for x and y components

### DIFF
--- a/recorder.cpp
+++ b/recorder.cpp
@@ -99,8 +99,8 @@ struct RecorderImplementation : public Recorder {
 
     RecorderImplementation(const std::string& outputPath, const std::string& videoOutputPrefix) :
             fileOutput(outputPath),
-            videoOutputPrefix(videoOutputPrefix),
-            output(this->fileOutput)
+            output(this->fileOutput),
+            videoOutputPrefix(videoOutputPrefix)
     {
         init();
     }

--- a/recorder.cpp
+++ b/recorder.cpp
@@ -23,14 +23,16 @@ struct RecorderImplementation : public Recorder {
             "time": 0.0,
             "sensor": {
                 "type": "gyroscope",
-                "values": [0.0, 0.0, 0.0]
+                "values": [0.0, 0.0, 0.0],
+                "temperature": 0.0
             }
         })"_json;
         json jAccelerometer = R"({
             "time": 0.0,
             "sensor": {
                 "type": "accelerometer",
-                "values": [0.0, 0.0, 0.0]
+                "values": [0.0, 0.0, 0.0],
+                "temperature": 0.0
             }
         })"_json;
         json jGps = R"({
@@ -111,16 +113,46 @@ struct RecorderImplementation : public Recorder {
         fileOutput.close();
     }
 
-    void addGyroscope(double t, double x, double y, double z) final {
-        workspace.jGyroscope["time"] = t;
-        workspace.jGyroscope["sensor"]["values"] = { x, y, z };
+    void addGyroscope(const GyroscopeData &d) final {
+        workspace.jGyroscope["time"] = d.t;
+        workspace.jGyroscope["sensor"]["values"] = { d.x, d.y, d.z };
+        workspace.jGyroscope["sensor"].erase("temperature");
+        if (d.temperature > 0.0) {
+          workspace.jGyroscope["sensor"]["temperature"] = d.temperature;
+        }
         output << workspace.jGyroscope.dump() << std::endl;
     }
 
-    void addAccelerometer(double t, double x, double y, double z) final {
-        workspace.jAccelerometer["time"] = t;
-        workspace.jAccelerometer["sensor"]["values"] = { x, y, z };
+    void addGyroscope(double t, double x, double y, double z) final {
+        GyroscopeData d {
+          .t = t,
+          .x = x,
+          .y = y,
+          .z = z,
+          .temperature = -1.0,
+        };
+        addGyroscope(d);
+    }
+
+    void addAccelerometer(const AccelerometerData &d) final {
+        workspace.jAccelerometer["time"] = d.t;
+        workspace.jAccelerometer["sensor"]["values"] = { d.x, d.y, d.z };
+        workspace.jAccelerometer["sensor"].erase("temperature");
+        if (d.temperature > 0.0) {
+          workspace.jAccelerometer["sensor"]["temperature"] = d.temperature;
+        }
         output << workspace.jAccelerometer.dump() << std::endl;
+    }
+
+    void addAccelerometer(double t, double x, double y, double z) final {
+        AccelerometerData d {
+          .t = t,
+          .x = x,
+          .y = y,
+          .z = z,
+          .temperature = -1.0,
+        };
+        addAccelerometer(d);
     }
 
     void setFrame(const FrameData& f) {

--- a/recorder.cpp
+++ b/recorder.cpp
@@ -10,7 +10,7 @@ using json = nlohmann::json;
 
 struct RecorderImplementation : public Recorder {
     std::ofstream fileOutput;
-    std::ostream& output;
+    std::ostream &output;
     std::string videoOutputPrefix;
     int frameNumberGroup = 0;
     std::map<int, int> frameNumbers = {};
@@ -83,21 +83,21 @@ struct RecorderImplementation : public Recorder {
         })"_json;
     } workspace;
 
-    RecorderImplementation(std::ostream& output) :
+    RecorderImplementation(std::ostream &output) :
         fileOutput(),
         output(output)
     {
         init();
     }
 
-    RecorderImplementation(const std::string& outputPath) :
+    RecorderImplementation(const std::string &outputPath) :
             fileOutput(outputPath),
             output(this->fileOutput)
     {
         init();
     }
 
-    RecorderImplementation(const std::string& outputPath, const std::string& videoOutputPrefix) :
+    RecorderImplementation(const std::string &outputPath, const std::string &videoOutputPrefix) :
             fileOutput(outputPath),
             output(this->fileOutput),
             videoOutputPrefix(videoOutputPrefix)
@@ -155,7 +155,7 @@ struct RecorderImplementation : public Recorder {
         addAccelerometer(d);
     }
 
-    void setFrame(const FrameData& f) {
+    void setFrame(const FrameData &f) {
         workspace.jFrame["time"] = f.t;
         workspace.jFrame["cameraInd"] = f.cameraInd;
 
@@ -179,7 +179,7 @@ struct RecorderImplementation : public Recorder {
         }
     }
 
-    void addFrame(const FrameData& f) final {
+    void addFrame(const FrameData &f) final {
         setFrame(f);
         workspace.jFrame["number"] = frameNumberGroup;
         workspace.jFrameGroup["time"] = f.t;
@@ -190,7 +190,7 @@ struct RecorderImplementation : public Recorder {
         frameNumberGroup++;
     }
 
-    void addFrameGroup(double t, const std::vector<FrameData>& frames) final {
+    void addFrameGroup(double t, const std::vector<FrameData> &frames) final {
         workspace.jFrameGroup["time"] = t;
         workspace.jFrameGroup["number"] = frameNumberGroup;
         workspace.jFrameGroup["frames"] = {};
@@ -293,11 +293,11 @@ struct RecorderImplementation : public Recorder {
 
 namespace recorder {
 
-std::unique_ptr<Recorder> Recorder::build(const std::string& outputPath) {
+std::unique_ptr<Recorder> Recorder::build(const std::string &outputPath) {
     return std::unique_ptr<Recorder>(new RecorderImplementation(outputPath));
 }
 
-std::unique_ptr<Recorder> Recorder::build(const std::string& outputPath, const std::string &videoOutputPath) {
+std::unique_ptr<Recorder> Recorder::build(const std::string &outputPath, const std::string &videoOutputPath) {
     std::string videoOutputPrefix = "";
     if (!videoOutputPath.empty()) {
         assert(videoOutputPath.size() >= 4);
@@ -307,7 +307,7 @@ std::unique_ptr<Recorder> Recorder::build(const std::string& outputPath, const s
     return std::unique_ptr<Recorder>(new RecorderImplementation(outputPath, videoOutputPrefix));
 }
 
-std::unique_ptr<Recorder> Recorder::build(std::ostream& output) {
+std::unique_ptr<Recorder> Recorder::build(std::ostream &output) {
     return std::unique_ptr<Recorder>(new RecorderImplementation(output));
 }
 

--- a/recorder.cpp
+++ b/recorder.cpp
@@ -128,8 +128,11 @@ struct RecorderImplementation : public Recorder {
         workspace.jFrame["cameraInd"] = f.cameraInd;
 
         workspace.jFrame.erase("cameraParameters");
-        if (f.focalLength > 0.0) {
-            workspace.jFrame["cameraParameters"]["focalLength"] = f.focalLength;
+        if (f.focalLengthX > 0.0) {
+            workspace.jFrame["cameraParameters"]["focalLengthX"] = f.focalLengthX;
+        }
+        if (f.focalLengthY > 0.0) {
+            workspace.jFrame["cameraParameters"]["focalLengthY"] = f.focalLengthY;
         }
         if (f.px > 0.0 && f.py > 0.0) {
             workspace.jFrame["cameraParameters"]["principalPointX"] = f.px;

--- a/recorder.hpp
+++ b/recorder.hpp
@@ -50,7 +50,9 @@ public:
      * Flush and close output file.
      */
     virtual void closeOutputFile() = 0;
+    virtual void addGyroscope(const GyroscopeData &d) = 0;
     virtual void addGyroscope(double t, double x, double y, double z) = 0;
+    virtual void addAccelerometer(const AccelerometerData &d) = 0;
     virtual void addAccelerometer(double t, double x, double y, double z) = 0;
     virtual void addFrame(const FrameData& f) = 0;
     virtual void addFrameGroup(double t, const std::vector<FrameData>& frames) = 0;

--- a/recorder.hpp
+++ b/recorder.hpp
@@ -19,7 +19,7 @@ public:
      *
      * @param outputPath Platform path to a non-existing file which has write permissions.
      */
-    static std::unique_ptr<Recorder> build(const std::string& outputPath);
+    static std::unique_ptr<Recorder> build(const std::string &outputPath);
     /**
      * New recorder that saves both a JSONL recording and AVI video recordings for frame
      * bitmap data (if present). To work, this requires the recorder to be compiled with
@@ -38,12 +38,12 @@ public:
      *  Note that the file name must end in ".avi" due to OpenCV restrictions
      *  (supprting other formats & codecs require nastier dependencies).
      */
-    static std::unique_ptr<Recorder> build(const std::string& outputPath, const std::string &videoOutputPath);
+    static std::unique_ptr<Recorder> build(const std::string &outputPath, const std::string &videoOutputPath);
 
     /**
      * @ param output Stream to which output will be written.
      */
-    static std::unique_ptr<Recorder> build(std::ostream& output);
+    static std::unique_ptr<Recorder> build(std::ostream &output);
     virtual ~Recorder();
 
     /**
@@ -54,8 +54,8 @@ public:
     virtual void addGyroscope(double t, double x, double y, double z) = 0;
     virtual void addAccelerometer(const AccelerometerData &d) = 0;
     virtual void addAccelerometer(double t, double x, double y, double z) = 0;
-    virtual void addFrame(const FrameData& f) = 0;
-    virtual void addFrameGroup(double t, const std::vector<FrameData>& frames) = 0;
+    virtual void addFrame(const FrameData &f) = 0;
+    virtual void addFrameGroup(double t, const std::vector<FrameData> &frames) = 0;
     virtual void addARKit(const Pose &pose) = 0;
     virtual void addGroundTruth(const Pose &pose) = 0;
     virtual void addOdometryOutput(const Pose &pose, const Vector3d &velocity) = 0;

--- a/test.cpp
+++ b/test.cpp
@@ -25,14 +25,16 @@ TEST_CASE( "recorder", "[jsonl-recorder]" ) {
     auto f0 = recorder::FrameData {
         .t = 0.0,
         .cameraInd = 0,
-        .focalLength = 1000.0,
+        .focalLengthX = 1000.0,
+        .focalLengthY = 1000.0,
         .px = 640.0,
         .py = 360.0
     };
     auto f1 = recorder::FrameData {
         .t = 0.0,
         .cameraInd = 1,
-        .focalLength = 1001.0,
+        .focalLengthX = 1001.0,
+        .focalLengthY = 1001.0,
         .px = 640.0,
         .py = 360.0
     };

--- a/types.hpp
+++ b/types.hpp
@@ -39,6 +39,18 @@ struct FrameData {
     /** Optional: Frame data as an OpenCV matrix. If present, recorded to a video file */
     const cv::Mat *frameData = nullptr;
 };
+
+struct AccelerometerData {
+  double t;
+  double x, y, z;
+  double temperature = -1.0;
+};
+
+struct GyroscopeData {
+  double t;
+  double x, y, z;
+  double temperature = -1.0;
+};
 } // namespace recorder
 
 #endif

--- a/types.hpp
+++ b/types.hpp
@@ -27,9 +27,13 @@ struct Pose {
 };
 
 struct FrameData {
+    /** Timestamp in seconds. Monotonically increasing */
     double t;
+    /** Index to separate multiple cameras. 0, 1, … */
     int cameraInd;
-    double focalLength;
+    double focalLengthX;
+    double focalLengthY;
+    /** Principal point **/
     double px;
     double py;
     /** Optional: Frame data as an OpenCV matrix. If present, recorded to a video file */


### PR DESCRIPTION
Breaks the API for adding frames to the recorder, but the fix for the user is trivial.

Also adds an optional temperature field for the IMU sensors. It is set via structs similar to `FrameData`, which seems like a more extensible approach than adding new arguments to `addGyroscope()` and `addAccelerometer()`.